### PR TITLE
Update zlib version in install_HDF5.sh

### DIFF
--- a/script/install_HDF5.sh
+++ b/script/install_HDF5.sh
@@ -12,15 +12,15 @@ if [ -d "$1/HDF5" -a -f "$1/HDF5/include/hdf5.h" ]; then
 fi
 
 if [ ! -d "$1/ZLIB"  -a x"$platform" != x"cygwin" ]; then
-  rm zlib-1.2.11.tar.gz
-  rm -rf zlib-1.2.11
-  wget https://zlib.net/zlib-1.2.11.tar.gz
+  rm zlib-1.2.12.tar.gz
+  rm -rf zlib-1.2.12
+  wget https://zlib.net/zlib-1.2.12.tar.gz
   if [ $? -ne 0 ]; then
     echo -e "\033[91;5;1m FAILED! Installation requires an Internet connection \033[0m"
     exit 1
   fi
-  tar -xf zlib-1.2.11.tar.gz
-  cd zlib-1.2.11
+  tar -xf zlib-1.2.12.tar.gz
+  cd zlib-1.2.12
 
   CC=mpicc ./configure --prefix=$1/ZLIB
   make -j $2


### PR DESCRIPTION
zlib 1.2.11 is not available for download anymore and users are asked to move to 1.2.12: https://www.zlib.net/
Please update the dependence as the current OpenFPM installation script fails!